### PR TITLE
Fix search bar: whitespaces, and persistence when cleared

### DIFF
--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -11,5 +11,5 @@ export const useDebounce = (value: string, delay = 500) => {
     return () => clearTimeout(handler);
   }, [value, delay]);
 
-  return debouncedValue;
+  return debouncedValue.trim();
 };

--- a/src/pages/SearchSpells/SearchSpells.tsx
+++ b/src/pages/SearchSpells/SearchSpells.tsx
@@ -78,6 +78,7 @@ const SearchSpells = () => {
       setSearchParams(newSearchParams);
     } else if (!searchTerm && !playerClass && !schoolOfMagic) {
       setCardData([]);
+      setSearchParams({});
     }
   }, [
     searchTerm,


### PR DESCRIPTION
Closes #3 

Fixes:
- leading and trailing whitespaces are removed from search
- when manually clearing a filter, remove filter from URL 